### PR TITLE
Add identification for threads

### DIFF
--- a/mordred/mordred.py
+++ b/mordred/mordred.py
@@ -189,7 +189,7 @@ class Mordred:
         if len(global_tasks) > 0:
             #FIXME timer is applied to all global_tasks, does it make sense?
             # All tasks are executed in the same thread sequentially
-            gt = TasksManager(global_tasks, None, stopper, self.config, big_delay)
+            gt = TasksManager(global_tasks, "Global tasks", stopper, self.config, big_delay)
             threads.append(gt)
             gt.start()
             if big_delay > 0:

--- a/mordred/task_manager.py
+++ b/mordred/task_manager.py
@@ -52,7 +52,7 @@ class TasksManager(threading.Thread):
         :backend_section: perceval backend section name
         :config: config object for the manager
         """
-        super().__init__()  # init the Thread
+        super().__init__(name=backend_section)  # init the Thread
         self.config = config
         self.tasks_cls = tasks_cls  # tasks classes to be executed
         self.tasks = []  # tasks to be executed


### PR DESCRIPTION
Using the name parameter, when creating threads, the name of the thread
can be set. These names are a bit more meaningful that "Thread-3",
for example.