### PR TITLE
[config] Add variable number of configuration files

### DIFF
--- a/bin/mordred
+++ b/bin/mordred
@@ -104,8 +104,9 @@ def parse_args():
         epilog='Software metrics for your peace of mind'
         )
 
-    parser.add_argument('-c','--config', help='Configuration file',
-                        dest='config_file')
+    parser.add_argument('-c','--config', help='Configuration files',
+                        type=str, nargs='+', default=['mordred.cfg'],
+                        dest='config_files')
     parser.add_argument('-t','--template', help='Create template configuration file',
                         dest='config_template_file')
     parser.add_argument('-p','--phases', nargs='*',
@@ -120,11 +121,11 @@ if __name__ == '__main__':
         Config.create_config_file(args.config_template_file)
         logger.info("Sample config file created in %s", args.config_template_file)
         sys.exit(0)
-    elif args.config_file is None:
+    elif args.config_files is None:
         logger.error("Option -t or -c is required")
         sys.exit(1)
 
-    config = Config(args.config_file)
+    config = Config(args.config_files[0], args.config_files[1:])
     config_dict = config.get_conf()
     logs_dir = config_dict['general']['logs_dir']
     debug_mode = config_dict['general']['debug']


### PR DESCRIPTION
Now -c accepts a list of configuration files, instead of only one. If only one is specified, it works as before.

If more than one is specified, all of them are read, in order. The paramerters they have cascade, that is,
parameters set in later files overwrite those set in previous files.

This is useful for splitting the configuration in several files. For example, all information related to the "local" setup (links and credentials for databases, for example) can be in one file, all information related to the characteristics of the dashboard in another (data sources, etc.), and all the information related to how to produce the dashboard (eg, `sleep`, `debug`, etc) in a third one. That way, we can have "generic" configurations that can be overridden for a particular purpose (such as having a general configuration for tests, while having a local configuration for setting up the details of the local testing environment).