### PR TITLE
[task_identities] Add new option strict-mapping to sortinghat config

### DIFF
--- a/mordred/config.py
+++ b/mordred/config.py
@@ -355,6 +355,13 @@ class Config():
                     "type": str,
                     "deprecated": "Use identities_api_token"
                 },
+                "strict_mapping":  {
+                    "optional": True,
+                    "default": True,
+                    "type": bool,
+                    "doc": "rigorous check of values in identities matching " + \
+                            "(i.e, well formed email addresses)"
+                },
                 "orgs_file": optional_string_none,
                 "identities_file": optional_empty_list,
                 "identities_export_url": optional_string_none,

--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -486,6 +486,8 @@ class TaskIdentitiesMerge(Task):
     def do_unify(self, kwargs):
         cmd = self.__build_sh_command()
         cmd += ['unify', '--fast-matching', '-m', kwargs['matching']]
+        if not kwargs['strict_mapping']:
+            cmd += ['--no-strict-matching']
         uuids = self.__execute_sh_command(cmd)
         return uuids
 
@@ -515,7 +517,8 @@ class TaskIdentitiesMerge(Task):
                     # cfg['sortinghat']['matching'] is an empty list
                     logger.debug('Unify not executed because empty algorithm')
                     continue
-                kwargs = {'matching':algo, 'fast_matching':True}
+                kwargs = {'matching':algo, 'fast_matching':True,
+                          'strict_mapping': cfg['sortinghat']['strict_mapping']}
                 logger.info("[sortinghat] Unifying identities using algorithm %s",
                             kwargs['matching'])
                 uuids = self.do_unify(kwargs)


### PR DESCRIPTION
If this strict-mapping option is set to False during unify the matching
will be done using a no strict-mapping option so emails and names that
are not wellformed are used for matching also.