### PR TITLE
[task_identities] Add reset_on_load param to activate the reset of identities on load

### DIFF
--- a/mordred/config.py
+++ b/mordred/config.py
@@ -362,6 +362,12 @@ class Config():
                     "doc": "rigorous check of values in identities matching " + \
                             "(i.e, well formed email addresses)"
                 },
+                "reset_on_load":  {
+                    "optional": True,
+                    "default": False,
+                    "type": bool,
+                    "doc": "Unmerge and remove affiliations for all identities on load"
+                },
                 "orgs_file": optional_string_none,
                 "identities_file": optional_empty_list,
                 "identities_export_url": optional_string_none,


### PR DESCRIPTION
With the sortinghat load command a param --reset could be provided
in order to unmerge all identities and remove the affiliations, so
the only affiliations and merging of identities come from the
identities file loaded.