### PR TITLE
[task_identities] Don't load identities if autorefresh is pending

### DIFF
--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -292,21 +292,15 @@ class TaskIdentitiesLoad(Task):
         # Identities loading from files. It could be in several formats.
         # Right now GrimoireLab and SortingHat formats are supported
         if 'identities_file' in cfg['sortinghat']:
-            if cfg['sortinghat']['identities_format'] == 'sortinghat':
-                try:
+            try:
+                if cfg['sortinghat']['identities_format'] == 'sortinghat':
                     load_sortinghat_identities(self.config)
-                except Exception:
-                    with TasksManager.IDENTITIES_TASKS_ON_LOCK:
-                        TasksManager.IDENTITIES_TASKS_ON = False
-                    raise
-
-            elif cfg['sortinghat']['identities_format'] == 'grimoirelab':
-                try:
+                elif cfg['sortinghat']['identities_format'] == 'grimoirelab':
                     load_grimoirelab_identities(self.config)
-                except Exception:
-                    with TasksManager.IDENTITIES_TASKS_ON_LOCK:
-                        TasksManager.IDENTITIES_TASKS_ON = False
-                    raise
+            except Exception:
+                with TasksManager.IDENTITIES_TASKS_ON_LOCK:
+                    TasksManager.IDENTITIES_TASKS_ON = False
+                raise
 
         with TasksManager.IDENTITIES_TASKS_ON_LOCK:
             TasksManager.IDENTITIES_TASKS_ON = False


### PR DESCRIPTION
The autorefresh identities list is built from unify output in a SortingHat state.
If we change this status before the refresh is done, for example
breaking identities in a load with reset, the autorefresh list won't
be valid anymore. Thus, until there iare no autorfresh identities,
the SortingHat state won't be changed loading identities.