### PR TITLE
[task_identities] Add support for '--no-email-validation' option in grimoirelab2sh

### DIFF
--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -226,6 +226,8 @@ class TaskIdentitiesLoad(Task):
             cmd = ['grimoirelab2sh', '-i', identities_filename,
                    '-s', cfg['general']['short_name'] + ':manual',
                    '-o', json_identities]
+            if not cfg['sortinghat']['strict_mapping']:
+                cmd += ['--no-email-validation']
             if self.__execute_command(cmd) != 0:
                 logger.error('Can not generate the SH JSON file from ' +
                              'GrimoireLab yaml file. Do the files exists? ' +


### PR DESCRIPTION
…rimoirelab2sh

If in mordred config file the option:

strict_mapping = false

is defined, then --no-email-validation is passed to grimoirelab2sh.