### PR TITLE
[tasks_project] Load projects in the initial tasks in mordred

### DIFF
--- a/mordred/config.py
+++ b/mordred/config.py
@@ -52,14 +52,6 @@ class Config():
         # Build self.conf
         self.__read_conf_files()
 
-        # If projects are not already loaded do it
-        from .task_projects import TaskProjects
-        if not TaskProjects.get_projects():
-            # logging is not yet ready
-            print("Loading projects")
-            TaskProjects(self).execute()
-            print("Done")
-
     @classmethod
     def backend_section_params(self):
         # Params that must exists in all backends
@@ -160,11 +152,6 @@ class Config():
                     "optional": False,
                     "default": "logs",
                     "type": str
-                },
-                "skip_initial_load": {
-                    "optional": True,
-                    "default": False,
-                    "type": bool
                 },
                 "bulk_size": {
                     "optional": True,

--- a/mordred/mordred.py
+++ b/mordred/mordred.py
@@ -281,6 +281,12 @@ class Mordred:
         if self.conf['phases']['identities']:
             tasks_cls = [TaskInitSortingHat]
             self.execute_tasks(tasks_cls)
+
+        logger.info("Loading projects")
+        tasks_cls = [TaskProjects]
+        self.execute_tasks(tasks_cls)
+        logger.info("Done")
+
         return
 
     def start(self):
@@ -313,15 +319,12 @@ class Mordred:
                 print('Can not access arthur service. Exiting mordred ...')
                 sys.exit(1)
 
-        # Initial round: panels loading
-        if not self.conf['general']['skip_initial_load']:
-            self.__execute_initial_load()
-        else:
-            logging.warning("Skipping the initial load")
+        # Initial round: panels and projects loading
+        self.__execute_initial_load()
 
         # Tasks to be executed during updating process
         all_tasks_cls = []
-        all_tasks_cls.append(TaskProjects)  # projects is always needed
+        all_tasks_cls.append(TaskProjects)  # projects update is always needed
         if self.conf['phases']['collection']:
             if not self.conf['es_collection']['arthur']:
                 all_tasks_cls.append(TaskRawDataCollection)

--- a/tests/test_task_collection.py
+++ b/tests/test_task_collection.py
@@ -34,6 +34,7 @@ sys.path.insert(0, '..')
 
 from mordred.config import Config
 from mordred.task_collection import TaskRawDataCollection
+from mordred.task_projects import TaskProjects
 
 CONF_FILE = 'test.cfg'
 PROJ_FILE = 'test-projects.json'
@@ -100,6 +101,8 @@ class TestTaskRawDataCollection(unittest.TestCase):
         config = Config(CONF_FILE)
         backend_section = GIT_BACKEND_SECTION
         task = TaskRawDataCollection(config, backend_section=backend_section)
+        # We need to load the projects
+        TaskProjects(config).execute()
         self.assertEqual(task.execute(), None)
 
 

--- a/tests/test_task_enrich.py
+++ b/tests/test_task_enrich.py
@@ -33,6 +33,7 @@ from sortinghat.db.database import Database
 sys.path.insert(0, '..')
 
 from mordred.config import Config
+from mordred.task_projects import TaskProjects
 from mordred.task_enrich import TaskEnrich
 
 CONF_FILE = 'test.cfg'
@@ -74,6 +75,8 @@ class TestTaskEnrich(unittest.TestCase):
         """Test whether the Task could be run"""
         config = Config(CONF_FILE)
         cfg = config.get_conf()
+        # We need to load the projects
+        TaskProjects(config).execute()
         backend_section = GIT_BACKEND_SECTION
         task = TaskEnrich(config, backend_section=backend_section)
         self.assertEqual(task.execute(), None)


### PR DESCRIPTION
The option skip_initial_load has been removed because it is
not usable anymore.

Now the projects are loaded in the initial tasks in mordred and not
from Config class, a hacky place to do that.