### PR TITLE
[panels] Use the new kidash module, instead of grimoire-kidash

### DIFF
--- a/mordred/task_panels.py
+++ b/mordred/task_panels.py
@@ -30,7 +30,7 @@ import yaml
 from collections import OrderedDict
 from urllib.parse import urljoin
 
-from grimoire_elk.panels import import_dashboard, get_dashboard_name, exists_dashboard
+from kidash.kidash import import_dashboard, get_dashboard_name, exists_dashboard
 from mordred.task import Task
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ setup(name="grimoire-mordred",
           'mordred'
       ],
       install_requires=[
-          'grimoire-elk>=0.30.7',
-          'grimoire-kidash>=0.30.4',
+          'grimoire-elk>=0.30.18',
+          'kidash>=0.4.0',
           'grimoire-reports>=0.1.0',
           'sortinghat>=0.4.2',
           'PyMySQL',


### PR DESCRIPTION
grimoire-kidash is now kidash, and it is unbundled from grimoire-elk.
This patch should make mordred work with this new schema.

This patch should be applied after grimoirelab/grimoireelk#155