### PR TITLE
[task_collection][arthur] Limit the total number of items collected from redis

### DIFF
--- a/mordred/task_collection.py
+++ b/mordred/task_collection.py
@@ -135,6 +135,7 @@ class TaskRawDataArthurCollection(Task):
     ARTHUR_LAST_MEMORY_CHECK_TIME = 0  # seconds needed to check the memory
     ARTHUR_LAST_MEMORY_SIZE = 0  # size in MB of the python dict
     ARTHUR_MAX_MEMORY_SIZE = 200  # max size in MB of the python dict
+    ARTHUR_REDIS_ITEMS = 1000  # number of raw items to collect from redis
 
     arthur_items = {}  # Hash with tag list with all items collected from arthur queue
 
@@ -198,8 +199,9 @@ class TaskRawDataArthurCollection(Task):
 
             # Get and remove queued items in an atomic transaction
             pipe = conn.pipeline()
-            pipe.lrange(Q_STORAGE_ITEMS, 0, -1)
-            pipe.ltrim(Q_STORAGE_ITEMS, 1, 0)
+            # pipe.lrange(Q_STORAGE_ITEMS, 0, -1)
+            pipe.lrange(Q_STORAGE_ITEMS, 0, self.ARTHUR_REDIS_ITEMS - 1)
+            pipe.ltrim(Q_STORAGE_ITEMS, self.ARTHUR_REDIS_ITEMS, -1)
             items = pipe.execute()[0]
 
             for item in items:


### PR DESCRIPTION
In redis the queue with raw items could be huge. In order to avoid issues
with the python memory dict with raw items, the items will be collected in
ARTHUR_REDIS_ITEMS packs (1000 by default).