### PR TITLE
[task_panels] Force the creation of .kibana index in Kibiter6 (update)

### DIFF
--- a/mordred/task_panels.py
+++ b/mordred/task_panels.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 ES6_HEADER = {"Content-Type": "application/json"}
 
 # We don't have this data so it just works for this value
-ES6_KIBANA_INIT_URL = "http://localhost:5601"
+ES6_KIBANA_INIT_URL = "http://kibiter:5601"
 ES6_KIBANA_INIT_URL += "/api/kibana/settings/indexPattern:placeholder"
 ES6_KIBANA_INIT_DATA = '{"value": "*"}'
 # We need the version before the .kibana exists so we can not find it


### PR DESCRIPTION
Use http://kibiter:5601 instead of http://localhost:5601.

If we decide to continue with this approach, this Kibana URL will be defined in mordred config file.