### PR TITLE
Refactor autorefresh code thanks to the last_update field in Sortinghat

### DIFF
--- a/mordred/mordred.py
+++ b/mordred/mordred.py
@@ -207,14 +207,6 @@ class Mordred:
         # launching threads for tasks by backend
         if len(backend_tasks) > 0:
             repos_backend = self._get_repos_by_backend()
-            # Init the shared dict to control if autorefresh must be done
-            backends_autorefresh = {backend: False for backend in repos_backend}
-            TasksManager.AUTOREFRESH_QUEUE.put(backends_autorefresh)
-            logger.debug("Initial Autorefresh queue: %s", backends_autorefresh)
-            # Init the shared dict to control the uuids to be autorefreshed in
-            # each backend
-            backends_autorefresh_uuids = {backend: [] for backend in repos_backend}
-            TasksManager.UPDATED_UUIDS_QUEUE.put(backends_autorefresh_uuids)
             for backend in repos_backend:
                 # Start new Threads and add them to the threads list to complete
                 t = TasksManager(backend_tasks, backend, stopper, self.config, small_delay)
@@ -244,18 +236,6 @@ class Mordred:
 
         # Checking for exceptions in threads to log them
         self.__check_queue_for_errors()
-
-        # Empty the shared queues. They must have just one item.
-        if TasksManager.AUTOREFRESH_QUEUE.qsize() != 1:
-            logger.warning("AUTOREFRESH_QUEUE final size: %i",
-                           TasksManager.AUTOREFRESH_QUEUE.qsize())
-        if TasksManager.UPDATED_UUIDS_QUEUE.qsize() != 1:
-            logger.warning("UPDATED_UUIDS_QUEUE final size: %i",
-                           TasksManager.UPDATED_UUIDS_QUEUE.qsize())
-        while not TasksManager.AUTOREFRESH_QUEUE.empty():
-            TasksManager.AUTOREFRESH_QUEUE.get()
-        while not TasksManager.UPDATED_UUIDS_QUEUE.empty():
-            TasksManager.UPDATED_UUIDS_QUEUE.get()
 
         logger.debug(" Task manager and all its tasks (threads) finished!")
 

--- a/mordred/task_enrich.py
+++ b/mordred/task_enrich.py
@@ -161,7 +161,7 @@ class TaskEnrich(Task):
         uuids_refresh = []
         after = self.last_autorefresh
         logger.debug('Getting last modified identities from SH since %s for %s', after, self.backend_section)
-        (uuids_refresh, ids) = api.search_last_modified_identities(self.db, after)
+        (uuids_refresh, ids_refresh) = api.search_last_modified_identities(self.db, after)
         self.last_autorefresh = datetime.utcnow()
         if uuids_refresh:
             logger.debug("Refreshing for %s uuids %s", self.backend_section, uuids_refresh)
@@ -171,6 +171,14 @@ class TaskEnrich(Task):
             enrich_backend.elastic.bulk_upload_sync(eitems, field_id)
         else:
             logger.debug("No uuids to be refreshed found")
+        if ids_refresh:
+            logger.debug("Refreshing for %s ids %s", self.backend_section, ids_refresh)
+            eitems = refresh_identities(enrich_backend,
+                                        {"name": "author_id",
+                                         "value": ids_refresh})
+            enrich_backend.elastic.bulk_upload_sync(eitems, field_id)
+        else:
+            logger.debug("No ids to be refreshed found")
 
     def __studies(self):
         logger.info("Executing %s studies ...", self.backend_section)

--- a/mordred/task_manager.py
+++ b/mordred/task_manager.py
@@ -42,10 +42,6 @@ class TasksManager(threading.Thread):
 
     # this queue supports the communication from threads to mother process
     COMM_QUEUE = queue.Queue()
-    # data sources that need a autorefresh execution
-    AUTOREFRESH_QUEUE = queue.Queue()
-    # uuids that must be refreshed in enriched data
-    UPDATED_UUIDS_QUEUE = queue.Queue()
     # to control if enrichment process are active
     NUMBER_ENRICH_TASKS_ON_LOCK = threading.Lock()
     NUMBER_ENRICH_TASKS_ON = 0


### PR DESCRIPTION
Now in the enrich process of each backend, the last modified uuids and uids
can be found and it can directly refresh those. Removed all the code needed
to communicate the identities to refresh from TaskIdentities to TaskEnrich tasks
which is not needed anymore.