### PR TITLE
[task_panels] Add mbox as data source to be shown if pipermail exists

### DIFF
--- a/mordred/task_panels.py
+++ b/mordred/task_panels.py
@@ -230,6 +230,10 @@ class TaskPanels(Task):
             logger.info("Not creating a panel that exists already: %s", dash_id)
         else:
             logger.info("Creating the panel: %s", dash_id)
+            if data_sources and 'pipermail' in data_sources:
+                # the dashboard for mbox and pipermail are the same
+                data_sources = list(data_sources)
+                data_sources.append('mbox')
             import_dashboard(es_enrich, panel_file, data_sources=data_sources)
 
     def execute(self):


### PR DESCRIPTION
In order to show the correct widgets in overview and data status panels
the data source to include in these panels is mbox, not pipermail. The
visualizations for both are the same.