### PR TITLE
[task_identities] Execute unify just after the load of identities in the same task

### DIFF
--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -218,6 +218,7 @@ class TaskIdentitiesLoad(Task):
                 res.raise_for_status()
                 identities = tempfile.NamedTemporaryFile()
                 identities.write(res.content)
+                identities.flush()
                 identities_filename = identities.name
 
             # Convert to a JSON file in SH format
@@ -233,7 +234,6 @@ class TaskIdentitiesLoad(Task):
                              'GrimoireLab yaml file. Do the files exists? ' +
                              'Is the API token right?')
             else:
-
                 # Load the JSON file in SH format
                 load_identities_file(json_identities, cfg['sortinghat']['reset_on_load'])
 
@@ -285,6 +285,17 @@ class TaskIdentitiesLoad(Task):
                 with TasksManager.IDENTITIES_TASKS_ON_LOCK:
                     TasksManager.IDENTITIES_TASKS_ON = False
                 raise
+            # After loading the identities we need to unify in order
+            # to mix the identites loaded with then ones from data sources
+            cmd = ['sortinghat', '-u', self.db_user, '-p', self.db_password,
+                   '--host', self.db_host, '-d', self.db_sh]
+            cmd += ['unify', '--fast-matching']
+            for algo in cfg['sortinghat']['matching']:
+                ucmd = cmd + ['-m', algo]
+                if not cfg['sortinghat']['strict_mapping']:
+                    ucmd += ['--no-strict-matching']
+                logger.debug("Doing unify after identities load")
+                self.__execute_command(ucmd)
 
         with TasksManager.IDENTITIES_TASKS_ON_LOCK:
             TasksManager.IDENTITIES_TASKS_ON = False


### PR DESCRIPTION
To avoid enriching data with identities that are not yet unified,
after the loading of identities, execute a unify process.

It is critial when loading identities with reset, because after the
loading of identities, all the identities loaded from data sources
are unmerged and unaffiliated because of the reset.

If the refresh of identities is done in this status the identities
in the enriched index will be "reseted" so all affiliations and
merging of identities will be lost.